### PR TITLE
Feat: Android CI build

### DIFF
--- a/.github/actions/google-drive-save/action.yml
+++ b/.github/actions/google-drive-save/action.yml
@@ -1,0 +1,59 @@
+name: Save to Google Drive 
+description: Saves given file to Google Drive 
+inputs:
+  projectName:
+    description: |
+      Name to use for the project, this will be a part of the saved filename
+    required: true
+  sourceRelPath:
+    description: Path of the source file
+    required: true
+  token:  
+    description: Google Drive token 
+    required: true
+  folderId:
+    description: Google drive folder Id for where to save the file
+    required: true
+  fileIdentifier:
+    description: A string such as a commit hash or a date to uniquely identify
+      a file. This will be appended to the filename.
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create variables
+      id: variables
+      shell: bash
+      run: |
+        project_name="${{ inputs.projectName }}"
+        release_filename="${project_name}-${{ inputs.fileIdentifier }}.apk"
+        latest_filename="${project_name}-latest.apk"
+
+        source_relpath="${{ inputs.sourceRelPath }}"
+
+        for i in \
+          release_filename \
+          latest_filename \
+          source_relpath;
+        do 
+          echo "$i=${!i}" >> $GITHUB_OUTPUT; 
+        done
+
+    - name: Upload "${{ steps.variables.outputs.commit_hash }}" to Google Drive
+      uses: adityak74/google-drive-upload-git-action@main
+      with:
+        credentials: "${{ inputs.token }}"
+        folderId: "${{ inputs.folderId }}"
+        name: ${{ steps.variables.outputs.release_filename }}
+        filename: ${{ steps.variables.outputs.source_relpath }}
+        overwrite: "false"
+
+    - name: Upload "latest" to Google Drive
+      uses: adityak74/google-drive-upload-git-action@main
+      with:
+        credentials: "${{ inputs.token }}"
+        folderId: "${{ inputs.folderId }}"
+        name: ${{ steps.variables.outputs.latest_filename }}
+        filename: ${{ steps.variables.outputs.source_relpath }}
+        overwrite: "true"

--- a/.github/workflows/android.build.wfc.yml
+++ b/.github/workflows/android.build.wfc.yml
@@ -1,0 +1,62 @@
+name: Build Android App
+
+on:
+  workflow_call:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
+    container:
+      image: utkusarioglu/react-native-android-devcontainer:1.0.18
+      options: --user=0:0
+    strategy:
+      matrix:
+        releases:
+          - repoRelPath: rn-vite-tauri-workshop
+            projectName: rn-vite-tauri-workshop
+            appRelPath: apps/android
+            apkReleaseDirRelPath: android/app/build/outputs/apk/release
+            appReleaseFilename: app-release.apk
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          path: ${{ matrix.releases.repoRelPath }}
+
+      - name: Set up variables
+        working-directory: "${{ matrix.releases.repoRelPath }}"
+        id: variables
+        env:
+          REPO_REL_PATH: ${{ matrix.releases.repoRelPath }}
+          APP_REL_PATH: ${{ matrix.releases.appRelPath }}
+          APK_RELEASE_DIR_REL_PATH: ${{ matrix.releases.apkReleaseDirRelpath }}
+          APP_RELEASE_FILENAME: ${{ matrix.releases.appReleaseFilename }}
+        run: scripts/github/output/android-variables.sh 
+
+      - name: Install monorepo dependencies
+        working-directory: "${{ matrix.releases.repoRelPath }}"
+        run: scripts/dependencies/android/install-immutable.sh
+
+      - name: Build android
+        working-directory: "${{ matrix.releases.repoRelPath }}/${{ matrix.releases.appRelPath }}"
+        run: yarn release:build
+
+      - name: Save to Google Drive
+        # TODO this path includes `matrix.images.repoRelPath` as
+        # `rn-vite-tauri-workshop` but cannot use the variable because of how
+        # github actions parses this workflow.
+        uses: "./rn-vite-tauri-workshop/.github/actions/google-drive-save"
+        with:
+          projectName: ${{ matrix.releases.projectName }}
+          sourceRelPath: ${{ steps.variables.outputs.source_file_relpath }}
+          fileIdentifier: ${{ steps.variables.outputs.file_identifier }}
+          token: "${{ secrets.GOOGLE_DRIVE_TOKEN }}"
+          folderId: "${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}"

--- a/.github/workflows/experiment.yml
+++ b/.github/workflows/experiment.yml
@@ -1,0 +1,32 @@
+name: Push
+
+on:
+  push:
+    tags:
+      - "experiment/**/**/**"
+    # paths:
+    #   - apps/**
+    #   - packages/**
+    #   - .github/workflows/push.yml
+    #   - .github/workflows/build-test-push.wfc.yml
+    #   - .github/workflows/web.build.wfc.yml
+    #   - .github/workflows/android.build.wfc.yml
+    #   - .github/workflows/web-server-endpoints.test.wfc.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  android-build:
+    uses: ./.github/workflows/android.build.wfc.yml
+    secrets: inherit
+    # permissions:
+    #   contents: write
+
+  tauri-build:
+    uses: ./.github/workflows/tauri.build.wfc.yml
+    secrets: inherit
+    # permissions:
+    #   contents: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,33 @@
+name: Push
+
+on:
+  push:
+    tags:
+      - "**.**.**"
+      # - "experiment/**/**/**"
+    # paths:
+    #   - apps/**
+    #   - packages/**
+    #   - .github/workflows/push.yml
+    #   - .github/workflows/build-test-push.wfc.yml
+    #   - .github/workflows/web.build.wfc.yml
+    #   - .github/workflows/android.build.wfc.yml
+    #   - .github/workflows/web-server-endpoints.test.wfc.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  android-build:
+    uses: ./.github/workflows/android.build.wfc.yml
+    secrets: inherit
+    # permissions:
+    #   contents: write
+
+  tauri-build:
+    uses: ./.github/workflows/tauri.build.wfc.yml
+    secrets: inherit
+    # permissions:
+    #   contents: write

--- a/.github/workflows/tauri.build.wfc.yml
+++ b/.github/workflows/tauri.build.wfc.yml
@@ -1,4 +1,4 @@
-name: tauri-build
+name: Build Tauri Apps
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
 jobs:
   release:
     runs-on: ${{ matrix.platform }}
-    permissions:
-      contents: write
+    # permissions:
+    #   contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +23,6 @@ jobs:
 
       - name: Install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-20.04'
-        # You can remove libayatana-appindicator3-dev if you don't use the system tray feature.
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
@@ -40,12 +39,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          cache: 'yarn' # Set this to npm, yarn or pnpm.
+          cache: 'yarn'
 
       - name: Install frontend dependencies
         working-directory: ./apps/linux
         # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
-        run: yarn install 
+        run: yarn install
 
       - name: Build the app
         uses: tauri-apps/tauri-action@v0
@@ -53,18 +52,9 @@ jobs:
           projectPath: apps/linux
           tauriScript: yarn tauri
       
-      - name: Archive code coverage results
+      - name: Save Msi Installer
         uses: actions/upload-artifact@v3
         with:
           name: windows-executables
-          path: apps/linux/src-tauri/target/release/bundle
-          retention-days: 1
-
-        # env:
-        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # with:
-        #   tagName: ${{ github.ref_name }} # This only works if your workflow triggers on new tags.
-        #   releaseName: 'App Name v__VERSION__' # tauri-action replaces \_\_VERSION\_\_ with the app version.
-        #   releaseBody: 'See the assets to download and install this version.'
-        #   releaseDraft: true
-        #   prerelease: false
+          path: apps/linux/src-tauri/target/release/bundle/msi
+          retention-days: 7

--- a/apps/android/android/app/build.gradle
+++ b/apps/android/android/app/build.gradle
@@ -39,8 +39,8 @@ react {
     //   The name of the generated asset file containing your JS bundle
     // bundleAssetName = "MyApplication.android.bundle"
     //
-    //   The entry file for bundle generation. Default is 'index.android.js' or 'index.js'
-    // entryFile = file("../js/MyApplication.android.js")
+    // The entry file for bundle generation. Default is 'index.android.js' or 'index.js'
+    entryFile = file("../../index.mjs")
     //
     //   A list of extra flags to pass to the 'bundle' commands.
     //   See https://github.com/react-native-community/cli/blob/main/docs/commands.md#bundle
@@ -49,6 +49,7 @@ react {
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
     // hermesCommand = "$rootDir/my-custom-hermesc/bin/hermesc"
+    hermesCommand = "../../node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]

--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -5,12 +5,12 @@
   "private": true,
   "main": "index.mjs",
   "scripts": {
-    "build:release": "cd android && ./gradlew assembleRelease",
-    "install:release": "adb install android/app/build/outputs/apk/release/app-release.apk",
-    "adb-connect": "adb connect $ANDROID_TARGET_DEVICE",
-    "rn-start": "TAMAGUI_TARGET=native react-native start",
-    "rn-android": "TAMAGUI_TARGET=native react-native run-android --no-packager --active-arch-only",
-    "dev": "yarn adb-connect && yarn rn-start & yarn rn-android",
+    "release:build": "cd android && ./gradlew assembleRelease",
+    "release:install": "adb install android/app/build/outputs/apk/release/app-release.apk",
+    "adb:connect": "adb connect $ANDROID_TARGET_DEVICE",
+    "rn:start": "TAMAGUI_TARGET=native react-native start",
+    "rn:android": "TAMAGUI_TARGET=native react-native run-android --no-packager --active-arch-only",
+    "dev": "yarn adb:connect && yarn rn:start & yarn rn:android",
     "dev:no-telemetry": "yarn dev",
     "lint": "eslint .",
     "test": "jest"

--- a/scripts/dependencies/android/install-immutable.sh
+++ b/scripts/dependencies/android/install-immutable.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+echo "Working directory content:"
+ls -al
+
+echo "Package.json content:"
+cat package.json
+
+echo "Installing immutable dependencies"
+yarn --immutable
+# yarn plugin import workspace-tools
+
+# cd packages/openapi
+# yarn generate:all
+# cd ../..
+
+# cd ${{ matrix.releases.appRelPath }}
+# yarn react-native-asset

--- a/scripts/github/output/android-variables.sh
+++ b/scripts/github/output/android-variables.sh
@@ -1,0 +1,47 @@
+# 
+# Creates variables that are needed by the android build workflow
+#
+
+REQUIRED_VARIABLES=(
+  REPO_REL_PATH 
+  APP_REL_PATH 
+  APK_RELEASE_DIR_REL_PATH 
+  APP_RELEASE_FILENAME
+)
+
+for env_var in ${REQUIRED_VARIABLES[*]}; do
+  if [ -z "${!env_var}" ]; then
+    echo "Error: ${env_var} is required for this script"
+    exit 1
+  fi
+done
+
+date_string="$(date +'%Y-%m-%dT-%H-%M-%S')"
+
+commit_hash="$(git rev-parse --short HEAD)"
+
+file_identifier="${date_string}-${commit_hash}"
+
+source_folder_relpath_arr=(
+  "${REPO_REL_PATH}"
+  "${APP_REL_PATH}"
+  "${APK_RELEASE_DIR_REL_PATH}"
+)
+source_folder_relpath=$(IFS='/'; echo "${source_folder_relpath_arr[*]}")
+
+source_file_relpath_arr=(
+  "${source_folder_relpath}"
+  "${APP_RELEASE_FILENAME}"
+)
+source_file_relpath=$(IFS='/'; echo "${source_file_relpath_arr[*]}")
+
+for i in \
+  commit_hash \
+  date_string \
+  file_identifier \
+  source_file_relpath \
+  source_folder_relpath;
+do 
+  echo "Setting: $i=${!i}"
+  echo "$i=${!i}" >> $GITHUB_OUTPUT;
+done


### PR DESCRIPTION
- Alter android build related scripts and configurations to get them to
  working order.
- Add multiple workflow scripts and actions for github actions to enable
  android building capability in CI.
- Add bash scripts to support the CI android build while keeping the
  workflows tidy.
